### PR TITLE
Add FastAPI app with /health endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- implement `main.py` with a simple FastAPI app
- expose a `/health` route returning `{"status": "ok"}`
- run the server with uvicorn when executed directly

## Testing
- `python main.py & sleep 5 && curl -s http://localhost:8000/health && echo`


------
https://chatgpt.com/codex/tasks/task_e_684d86f3425483278fc89fcd45cbe0ab