### PR TITLE
Add Pydantic settings loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # SurpassApp
 Surpass utility application
+
+## Settings
+
+The project uses [Pydantic](https://docs.pydantic.dev/) to load configuration from a `.env` file. Create a file named `.env` in the project root with the following variables:
+
+```
+SURPASS_USER=<your user>
+SURPASS_PASS=<your password>
+```
+
+Then you can import `Settings` from `settings.py`:
+
+```python
+from settings import Settings
+
+settings = Settings()
+print(settings.surpass_user)
+```

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,12 @@
+from pydantic import BaseSettings
+
+class Settings(BaseSettings):
+    surpass_user: str
+    surpass_pass: str
+
+    class Config:
+        env_file = '.env'
+        env_file_encoding = 'utf-8'
+        env_prefix = ''
+
+settings = Settings()


### PR DESCRIPTION
## Summary
- add `settings.py` with Pydantic `BaseSettings`
- document how to configure the new settings in the README

## Testing
- `python3 -m py_compile settings.py`
- `python3 - <<'PY'
from settings import Settings
s=Settings()
print(s.surpass_user, s.surpass_pass)
PY`

------
https://chatgpt.com/codex/tasks/task_e_684d86fc49288327b03ff554155c1d43