### PR TITLE
Update API client and TestSession model

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,15 @@ from settings import Settings
 settings = Settings()
 print(settings.surpass_user)
 ```
+
+## Fetching Test Sessions
+
+Use `fetch_test_sessions` to retrieve test sessions from the Surpass API:
+
+```python
+from SurpassApp.reporting.client import fetch_test_sessions
+
+sessions = fetch_test_sessions()
+for session in sessions:
+    print(session.id, session.reference)
+```

--- a/SurpassApp/reporting/client.py
+++ b/SurpassApp/reporting/client.py
@@ -11,5 +11,6 @@ def fetch_test_sessions() -> List[TestSession]:
     resp = requests.get(f"{BASE_URL}/TestSession", auth=auth)
     if resp.status_code != 200:
         resp.raise_for_status()
-    items = resp.json()
+    data = resp.json()
+    items = data.get("response", [])
     return [TestSession(**it) for it in items]

--- a/SurpassApp/reporting/models.py
+++ b/SurpassApp/reporting/models.py
@@ -1,8 +1,42 @@
 # surpass_app/reporting/models.py
 from pydantic import BaseModel
 
+
+class Candidate(BaseModel):
+    id: int
+    href: str
+
+
+class TestForm(BaseModel):
+    id: int
+    reference: str
+    name: str
+    href: str
+
+
+class Centre(BaseModel):
+    id: int
+    href: str
+
+
+class Test(BaseModel):
+    id: int
+    reference: str
+    name: str
+    href: str
+
+
 class TestSession(BaseModel):
-    id: str
-    candidate_name: str
-    score: float
-    status: str
+    id: int
+    reference: str
+    href: str
+    awaitingMarkingSubmission: bool | None = None
+    markingProgressPercent: int | None = None
+    candidate: Candidate | None = None
+    testForm: TestForm | None = None
+    centre: Centre | None = None
+    test: Test | None = None
+    currentExamState: str | None = None
+    downloadedToSecureClient: bool | None = None
+    errors: str | None = None
+    serverTimeZone: str | None = None


### PR DESCRIPTION
## Summary
- update `TestSession` model to use fields returned by Surpass API
- use `response` key from API response when creating models
- document fetching test sessions in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684da11fc77483278e13d287e3e61ca7