### PR TITLE
Fix test path ordering and add package init

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,12 +1,13 @@
 # tests/test_client.py
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 import pytest
 import requests
 from requests_mock import Mocker
 from SurpassApp.reporting.client import fetch_test_sessions
 from SurpassApp.reporting.models import TestSession
-import sys
-import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- make SurpassApp a package by adding `__init__`
- configure tests to add the repository path before importing project modules

## Testing
- `pytest -q` *(fails: NoMockAddress)*

------
https://chatgpt.com/codex/tasks/task_e_684dce1f2360832786642e2278131562