### PR TITLE
Add Surpass brand-themed light/dark styles

### DIFF
--- a/static/css/style-dark.css
+++ b/static/css/style-dark.css
@@ -1,0 +1,21 @@
+:root {
+  --color-primary: #36aae0;
+  --color-secondary: #12a364;
+  --color-accent: #f08021;
+  --color-success: #12a364;
+  --color-info: #36aae0;
+  --background: #1d1f21;
+  --surface: #333333;
+  --text-color: #f4f4f4;
+  --table-alt: #2a2c2e;
+  --font-family: 'Segoe UI', Arial, sans-serif;
+}
+
+body { font-family: var(--font-family); margin: 0; padding: 1rem; background: var(--background); color: var(--text-color); }
+header, footer { background: var(--surface); padding: 0.5rem 1rem; }
+nav a { margin-right: 1rem; text-decoration: none; color: var(--color-primary); }
+nav a:hover { color: var(--color-accent); }
+table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+th, td { padding: 0.5rem; border: 1px solid #555; }
+tbody tr:nth-child(even) { background: var(--table-alt); }
+button.theme-toggle { float: right; margin-left: 1rem; }

--- a/static/css/style-light.css
+++ b/static/css/style-light.css
@@ -1,0 +1,21 @@
+:root {
+  --color-primary: #1b66b0;
+  --color-secondary: #275163;
+  --color-accent: #f08021;
+  --color-success: #12a364;
+  --color-info: #36aae0;
+  --background: #ffffff;
+  --surface: #f4f4f4;
+  --text-color: #1f1f1f;
+  --table-alt: #fafafa;
+  --font-family: 'Segoe UI', Arial, sans-serif;
+}
+
+body { font-family: var(--font-family); margin: 0; padding: 1rem; background: var(--background); color: var(--text-color); }
+header, footer { background: var(--surface); padding: 0.5rem 1rem; }
+nav a { margin-right: 1rem; text-decoration: none; color: var(--color-primary); }
+nav a:hover { color: var(--color-accent); }
+table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+th, td { padding: 0.5rem; border: 1px solid #ddd; }
+tbody tr:nth-child(even) { background: var(--table-alt); }
+button.theme-toggle { float: right; margin-left: 1rem; }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,6 +1,0 @@
-body { font-family: sans-serif; margin: 0; padding: 1rem; }
-header, footer { background: #f4f4f4; padding: 0.5rem 1rem; }
-nav a { margin-right: 1rem; text-decoration: none; }
-table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
-th, td { padding: 0.5rem; border: 1px solid #ddd; }
-tbody tr:nth-child(even) { background: #fafafa; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,11 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <title>{{ title or "Surpass Utilities" }}</title>
-  <link rel="stylesheet" href="{{ url_for('static', path='css/style.css') }}" />
+  <link id="theme-link" rel="stylesheet" href="{{ url_for('static', path='css/style-light.css') }}" />
 </head>
 <body>
   <header>
     <h1>Surpass Utilities</h1>
+    <button class="theme-toggle" onclick="toggleTheme()">Toggle Theme</button>
     <nav>
       <a href="/">Home</a> |
       <a href="/reports/test-sessions">Test Sessions</a>
@@ -22,5 +23,23 @@
   <footer>
     <small>© 2025 Surpass Utilities</small>
   </footer>
+  <script>
+    function setTheme(theme) {
+      const link = document.getElementById('theme-link');
+      link.href = '/static/css/style-' + theme + '.css';
+      localStorage.setItem('theme', theme);
+    }
+
+    function toggleTheme() {
+      const current = localStorage.getItem('theme') || 'light';
+      const next = current === 'light' ? 'dark' : 'light';
+      setTheme(next);
+    }
+
+    (function() {
+      const saved = localStorage.getItem('theme') || 'light';
+      setTheme(saved);
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Surpass inspired light/dark color palettes
- implement theme toggle in base template

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685075f7ae4483278ce2d7e01b637fc5