### PR TITLE
Add home screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # SurpassApp
 Surpass utility application
 
+## Home Screen
+
+Start the FastAPI app using `python main.py` and navigate to `http://localhost:8000/`.
+The home page provides a short overview of the available modules and links to key routes.
+
 ## Settings
 
 The project uses [Pydantic](https://docs.pydantic.dev/) to load configuration from a `.env` file. Create a file named `.env` in the project root with the following variables:

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 # main.py
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from SurpassApp.core.config import settings
@@ -19,6 +19,13 @@ templates = Jinja2Templates(directory="templates")
 app.include_router(reporting_router)
 app.include_router(imports_router)
 app.include_router(users_router)
+
+@app.get("/")
+def home(request: Request):
+    """Render the application home screen with site overview."""
+    return templates.TemplateResponse(
+        "home.html", {"request": request, "title": "Home"}
+    )
 
 @app.get("/health")
 def health_check():

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <h2>Welcome to Surpass Utilities</h2>
+  <p>This application offers a few tools that interface with the Surpass API.</p>
+  <h3>Site Map</h3>
+  <ul>
+    <li><strong>Reports</strong>
+      <ul>
+        <li><a href="/reports/test-sessions">Test Sessions</a> &ndash; View recent test session data.</li>
+        <li><code>/reports/test-sessions/json</code> &ndash; JSON listing of test sessions.</li>
+      </ul>
+    </li>
+    <li><strong>Imports</strong>
+      <ul>
+        <li><code>/imports/ping</code> &ndash; Check the imports module status.</li>
+      </ul>
+    </li>
+    <li><strong>Users</strong>
+      <ul>
+        <li><code>/users/ping</code> &ndash; Check the users module status.</li>
+      </ul>
+    </li>
+  </ul>
+  <p>Use the navigation links above to explore the available utilities.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- provide a web home screen with a site map
- link home route into the FastAPI app
- document new page in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507b22d65083279cf420fe1cf74884