### PR TITLE
Add React test sessions view

### DIFF
--- a/SurpassApp/reporting/routes.py
+++ b/SurpassApp/reporting/routes.py
@@ -44,3 +44,11 @@ def view_test_sessions(request: Request):
         "test_sessions.html",
         {"request": request, "sessions": sessions}
     )
+
+@router.get("/test-sessions/react", summary="Test Sessions React view")
+def view_test_sessions_react(request: Request):
+    """Render a React-based page that fetches session data asynchronously."""
+    return templates.TemplateResponse(
+        "test_sessions_react.html",
+        {"request": request}
+    )

--- a/templates/home.html
+++ b/templates/home.html
@@ -8,6 +8,7 @@
     <li><strong>Reports</strong>
       <ul>
         <li><a href="/reports/test-sessions">Test Sessions</a> &ndash; View recent test session data.</li>
+        <li><a href="/reports/test-sessions/react">React View</a> &ndash; Dynamic report using React.</li>
         <li><code>/reports/test-sessions/json</code> &ndash; JSON listing of test sessions.</li>
       </ul>
     </li>

--- a/templates/test_sessions_react.html
+++ b/templates/test_sessions_react.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <h2>Test Sessions React View</h2>
+  <div id="root"></div>
+  <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@mui/material@5.15.8/umd/material-ui.development.js" crossorigin></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <script type="text/babel">
+    const { useState, useEffect } = React;
+    const { Table, TableBody, TableCell, TableHead, TableRow, CircularProgress, Alert } = MaterialUI;
+
+    function SessionsTable() {
+      const [sessions, setSessions] = useState([]);
+      const [loading, setLoading] = useState(true);
+      const [error, setError] = useState(null);
+
+      useEffect(() => {
+        fetch('/reports/test-sessions/json')
+          .then(res => {
+            if (!res.ok) {
+              throw new Error('Failed to load sessions');
+            }
+            return res.json();
+          })
+          .then(data => setSessions(data))
+          .catch(err => setError(err.toString()))
+          .finally(() => setLoading(false));
+      }, []);
+
+      if (loading) {
+        return <CircularProgress />;
+      }
+      if (error) {
+        return <Alert severity="error">{error}</Alert>;
+      }
+      return (
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>ID</TableCell>
+              <TableCell>Candidate</TableCell>
+              <TableCell>Score</TableCell>
+              <TableCell>Status</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {sessions.map(s => (
+              <TableRow key={s.id}>
+                <TableCell>{s.id}</TableCell>
+                <TableCell>{s.candidate_name}</TableCell>
+                <TableCell>{s.score}</TableCell>
+                <TableCell>{s.status}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      );
+    }
+
+    ReactDOM.render(<SessionsTable />, document.getElementById('root'));
+  </script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add React-based page for test sessions using Material UI
- expose new `/reports/test-sessions/react` endpoint
- link React view from home page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685607aa5c6c83278ef9ceccb7852f4b