### PR TITLE
Adjust Vite base path

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/app/',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- set `/app/` as the base URL in the Vite config
- rebuild frontend assets to regenerate `dist`

## Testing
- `npm run build`
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_68560ad9fadc8327a3451eee61a9738a