### PR TITLE
Fix dist folder ignore

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -8,7 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
-dist
+dist/
 dist-ssr
 *.local
 


### PR DESCRIPTION
## Summary
- ensure `dist/` in frontend gitignore

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68560ada911c8327ad88052f759d32fe