### PR TITLE
Remove unused imports

### DIFF
--- a/SurpassApp/core/auth.py
+++ b/SurpassApp/core/auth.py
@@ -1,6 +1,5 @@
 # surpass_app/core/auth.py
 import base64
-from typing import Dict
 from SurpassApp.core.config import settings
 
 def get_basic_auth_header() -> dict[str, str]:

--- a/SurpassApp/reporting/routes.py
+++ b/SurpassApp/reporting/routes.py
@@ -1,7 +1,6 @@
 # surpass_app/reporting/routes.py
 from fastapi import APIRouter, Request, HTTPException
 from typing import List
-from SurpassApp.core.auth import get_basic_auth_header
 from SurpassApp.reporting.client import fetch_test_sessions, check_surpass_connection
 from SurpassApp.reporting.models import TestSession
 import requests


### PR DESCRIPTION
## Summary
- delete unused `Dict` import in auth
- delete unused `get_basic_auth_header` import in reporting routes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68560adccbd88327a88a70a18ed7e63f