### PR TITLE
Add reusable React components and integrate into App

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,10 +1,10 @@
 import { useMemo, useState } from 'react'
-import { ThemeProvider, CssBaseline, AppBar, Toolbar, IconButton, Button, Container } from '@mui/material'
-import { Brightness4, Brightness7 } from '@mui/icons-material'
-import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom'
+import { ThemeProvider, CssBaseline, Container } from '@mui/material'
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
 import { lightTheme, darkTheme } from './theme'
 import Home from './pages/Home'
 import Sessions from './pages/Sessions'
+import { Header, Footer } from './components'
 
 export default function App() {
   const [mode, setMode] = useState(() => localStorage.getItem('theme') || 'light')
@@ -21,21 +21,14 @@ export default function App() {
     <ThemeProvider theme={theme}>
       <CssBaseline />
       <Router>
-        <AppBar position="static">
-          <Toolbar>
-            <Button color="inherit" component={Link} to="/">Home</Button>
-            <Button color="inherit" component={Link} to="/sessions">Sessions</Button>
-            <IconButton color="inherit" onClick={toggleTheme} sx={{ marginLeft: 'auto' }}>
-              {mode === 'light' ? <Brightness7 /> : <Brightness4 />}
-            </IconButton>
-          </Toolbar>
-        </AppBar>
+        <Header mode={mode} toggleTheme={toggleTheme} />
         <Container sx={{ marginTop: 2 }}>
           <Routes>
             <Route path="/" element={<Home />} />
             <Route path="/sessions" element={<Sessions />} />
           </Routes>
         </Container>
+        <Footer />
       </Router>
     </ThemeProvider>
   )

--- a/frontend/src/components/DataTable.jsx
+++ b/frontend/src/components/DataTable.jsx
@@ -1,0 +1,35 @@
+import { Table, TableHead, TableBody, TableRow, TableCell } from '@mui/material'
+import PropTypes from 'prop-types'
+
+export default function DataTable({ columns, rows }) {
+  return (
+    <Table>
+      <TableHead>
+        <TableRow>
+          {columns.map(col => (
+            <TableCell key={col.field}>{col.headerName}</TableCell>
+          ))}
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {rows.map((row, index) => (
+          <TableRow key={row.id || index}>
+            {columns.map(col => (
+              <TableCell key={col.field}>{row[col.field]}</TableCell>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}
+
+DataTable.propTypes = {
+  columns: PropTypes.arrayOf(
+    PropTypes.shape({
+      field: PropTypes.string.isRequired,
+      headerName: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+  rows: PropTypes.arrayOf(PropTypes.object).isRequired,
+}

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -1,0 +1,11 @@
+import { Box, Typography } from '@mui/material'
+
+export default function Footer() {
+  return (
+    <Box component="footer" sx={{ padding: 2, textAlign: 'center' }}>
+      <Typography variant="body2" color="text.secondary">
+        &copy; {new Date().getFullYear()} SurpassApp
+      </Typography>
+    </Box>
+  )
+}

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,0 +1,23 @@
+import { AppBar, Toolbar, IconButton, Button } from '@mui/material'
+import { Brightness4, Brightness7 } from '@mui/icons-material'
+import { Link as RouterLink } from 'react-router-dom'
+import PropTypes from 'prop-types'
+
+export default function Header({ mode, toggleTheme }) {
+  return (
+    <AppBar position="static">
+      <Toolbar>
+        <Button color="inherit" component={RouterLink} to="/">Home</Button>
+        <Button color="inherit" component={RouterLink} to="/sessions">Sessions</Button>
+        <IconButton color="inherit" onClick={toggleTheme} sx={{ marginLeft: 'auto' }}>
+          {mode === 'light' ? <Brightness7 /> : <Brightness4 />}
+        </IconButton>
+      </Toolbar>
+    </AppBar>
+  )
+}
+
+Header.propTypes = {
+  mode: PropTypes.string.isRequired,
+  toggleTheme: PropTypes.func.isRequired,
+}

--- a/frontend/src/components/PrimaryButton.jsx
+++ b/frontend/src/components/PrimaryButton.jsx
@@ -1,0 +1,11 @@
+import { styled, Button } from '@mui/material'
+
+const PrimaryButton = styled(Button)(({ theme }) => ({
+  color: theme.palette.common.white,
+  backgroundColor: '#004687',
+  '&:hover': {
+    backgroundColor: '#002D62',
+  },
+}))
+
+export default PrimaryButton

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -1,0 +1,4 @@
+export { default as Header } from './Header.jsx'
+export { default as Footer } from './Footer.jsx'
+export { default as PrimaryButton } from './PrimaryButton.jsx'
+export { default as DataTable } from './DataTable.jsx'


### PR DESCRIPTION
## Summary
- add Header/Footer/PrimaryButton/DataTable in new components directory
- export components from a single index
- refactor App.jsx to use Header and Footer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68572581d52c8327863ec5287413ab76