### PR TITLE
Add layout wrapper and table component

### DIFF
--- a/frontend/src/components/DataTable.jsx
+++ b/frontend/src/components/DataTable.jsx
@@ -1,0 +1,26 @@
+import { Table, TableBody, TableCell, TableHead, TableRow } from '@mui/material'
+
+export default function DataTable({ rows }) {
+  return (
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          <TableCell>ID</TableCell>
+          <TableCell>Candidate</TableCell>
+          <TableCell>Score</TableCell>
+          <TableCell>Status</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {(rows || []).map((r) => (
+          <TableRow key={r.id}>
+            <TableCell>{r.id}</TableCell>
+            <TableCell>{r.candidate_name}</TableCell>
+            <TableCell>{r.score}</TableCell>
+            <TableCell>{r.status}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}

--- a/frontend/src/components/PageLayout.jsx
+++ b/frontend/src/components/PageLayout.jsx
@@ -1,0 +1,40 @@
+import { AppBar, Toolbar, IconButton, Button, Container, Box, Typography } from '@mui/material'
+import { Brightness4, Brightness7 } from '@mui/icons-material'
+import { Link } from 'react-router-dom'
+import { useMemo, useState } from 'react'
+import { ThemeProvider, CssBaseline } from '@mui/material'
+import { lightTheme, darkTheme } from '../theme'
+
+export default function PageLayout({ children }) {
+  const [mode, setMode] = useState(() => localStorage.getItem('theme') || 'light')
+  const theme = useMemo(() => (mode === 'light' ? lightTheme : darkTheme), [mode])
+
+  const toggleTheme = () => {
+    const next = mode === 'light' ? 'dark' : 'light'
+    setMode(next)
+    localStorage.setItem('theme', next)
+  }
+
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <Box display="flex" flexDirection="column" minHeight="100vh">
+        <AppBar position="static">
+          <Toolbar>
+            <Button color="inherit" component={Link} to="/">Home</Button>
+            <Button color="inherit" component={Link} to="/sessions">Sessions</Button>
+            <IconButton color="inherit" onClick={toggleTheme} sx={{ marginLeft: 'auto' }}>
+              {mode === 'light' ? <Brightness7 /> : <Brightness4 />}
+            </IconButton>
+          </Toolbar>
+        </AppBar>
+        <Container sx={{ mt: 2, flexGrow: 1 }}>
+          {children}
+        </Container>
+        <Box component="footer" sx={{ p: 2, textAlign: 'center' }}>
+          <Typography variant="caption">© 2025 Surpass Utilities</Typography>
+        </Box>
+      </Box>
+    </ThemeProvider>
+  )
+}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,5 +1,10 @@
 import { Typography } from '@mui/material'
+import PageLayout from '../components/PageLayout'
 
 export default function Home() {
-  return <Typography variant="h4" component="h2">Home Page</Typography>
+  return (
+    <PageLayout>
+      <Typography variant="h4" component="h2">Home Page</Typography>
+    </PageLayout>
+  )
 }

--- a/frontend/src/pages/Sessions.jsx
+++ b/frontend/src/pages/Sessions.jsx
@@ -1,5 +1,41 @@
-import { Typography } from '@mui/material'
+import { Typography, CircularProgress, Alert } from '@mui/material'
+import { useEffect, useState } from 'react'
+import PageLayout from '../components/PageLayout'
+import DataTable from '../components/DataTable'
 
 export default function Sessions() {
-  return <Typography variant="h4" component="h2">Sessions Page</Typography>
+  const [sessions, setSessions] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    fetch('/reports/test-sessions/json')
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error('Failed to load sessions')
+        }
+        return res.json()
+      })
+      .then((data) => setSessions(data))
+      .catch((err) => setError(err.toString()))
+      .finally(() => setLoading(false))
+  }, [])
+
+  let content
+  if (loading) {
+    content = <CircularProgress data-testid="loading" />
+  } else if (error) {
+    content = <Alert severity="error">{error}</Alert>
+  } else {
+    content = <DataTable rows={sessions} />
+  }
+
+  return (
+    <PageLayout>
+      <Typography variant="h4" component="h2" gutterBottom>
+        Sessions
+      </Typography>
+      {content}
+    </PageLayout>
+  )
 }


### PR DESCRIPTION
## Summary
- create shared `PageLayout` with header and footer
- create reusable `DataTable`
- wrap `Home` and `Sessions` pages with `PageLayout`
- render session data in `Sessions` via `DataTable`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857258273588327a2aaca534067de0b