### PR TITLE
Add overview and site map to React home

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,7 +21,7 @@ export default function App() {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <Router>
+      <Router basename="/app">
         <Header mode={mode} toggleTheme={toggleTheme} />
         <Container sx={{ marginTop: 2 }}>
           <Routes>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,10 +1,79 @@
-import { Typography } from '@mui/material'
+import { Typography, List, ListItem, Link } from '@mui/material'
 import PageLayout from '../components/PageLayout'
 
 export default function Home() {
-  return {
+  return (
     <PageLayout>
-      <Typography variant="h4" component="h2">Home Page</Typography>
+      <Typography variant="h4" component="h2" gutterBottom>
+        Welcome to Surpass Utilities
+      </Typography>
+      <Typography paragraph>
+        This application offers a few tools that interface with the Surpass API.
+      </Typography>
+
+      <Typography variant="h5" component="h3" gutterBottom>
+        Site Map
+      </Typography>
+
+      <List sx={{ listStyleType: 'disc', pl: 2 }}>
+        <ListItem disableGutters sx={{ display: 'list-item' }}>
+          <Typography component="span" fontWeight="bold">
+            Reports
+          </Typography>
+          <List sx={{ listStyleType: 'circle', pl: 4 }}>
+            <ListItem disableGutters sx={{ display: 'list-item' }}>
+              <Link href="/reports/test-sessions">Test Sessions</Link> – View
+              recent test session data.
+            </ListItem>
+            <ListItem disableGutters sx={{ display: 'list-item' }}>
+              <Link href="/reports/test-sessions/react">React View</Link> –
+              Dynamic report using React.
+            </ListItem>
+            <ListItem disableGutters sx={{ display: 'list-item' }}>
+              <code>/reports/test-sessions/json</code> – JSON listing of test
+              sessions.
+            </ListItem>
+          </List>
+        </ListItem>
+
+        <ListItem disableGutters sx={{ display: 'list-item' }}>
+          <Typography component="span" fontWeight="bold">
+            Imports
+          </Typography>
+          <List sx={{ listStyleType: 'circle', pl: 4 }}>
+            <ListItem disableGutters sx={{ display: 'list-item' }}>
+              <code>/imports/ping</code> – Check the imports module status.
+            </ListItem>
+          </List>
+        </ListItem>
+
+        <ListItem disableGutters sx={{ display: 'list-item' }}>
+          <Typography component="span" fontWeight="bold">
+            Users
+          </Typography>
+          <List sx={{ listStyleType: 'circle', pl: 4 }}>
+            <ListItem disableGutters sx={{ display: 'list-item' }}>
+              <code>/users/ping</code> – Check the users module status.
+            </ListItem>
+          </List>
+        </ListItem>
+
+        <ListItem disableGutters sx={{ display: 'list-item' }}>
+          <Typography component="span" fontWeight="bold">
+            React
+          </Typography>
+          <List sx={{ listStyleType: 'circle', pl: 4 }}>
+            <ListItem disableGutters sx={{ display: 'list-item' }}>
+              <Link href="/app/demo">Demo App</Link> – Explore the React
+              interface.
+            </ListItem>
+          </List>
+        </ListItem>
+      </List>
+
+      <Typography paragraph>
+        Use the navigation links above to explore the available utilities.
+      </Typography>
     </PageLayout>
   )
 }


### PR DESCRIPTION
## Summary
- add same content as `home.html` to the React Home page
- configure React Router basename for `/app`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68574ba5ba78832795dc081c2bc7928a