### PR TITLE
Implement SPA sessions view

### DIFF
--- a/SurpassApp/reporting/routes.py
+++ b/SurpassApp/reporting/routes.py
@@ -1,5 +1,6 @@
 # surpass_app/reporting/routes.py
 from fastapi import APIRouter, Request, HTTPException
+from fastapi.responses import RedirectResponse
 from typing import List
 from SurpassApp.reporting.client import fetch_test_sessions, check_surpass_connection
 from SurpassApp.reporting.models import TestSession
@@ -33,16 +34,10 @@ def check_connection():
     except requests.HTTPError as e:
         raise HTTPException(status_code=502, detail=f"Auth failed: {e}")
     
-@router.get("/test-sessions", summary="Test Sessions (HTML view)")
-def view_test_sessions(request: Request):
-    try:
-        sessions: List[TestSession] = fetch_test_sessions()
-    except requests.HTTPError as e:
-        raise HTTPException(status_code=502, detail=str(e))
-    return templates.TemplateResponse(
-        "test_sessions.html",
-        {"request": request, "sessions": sessions}
-    )
+@router.get("/test-sessions", summary="Test Sessions SPA", include_in_schema=False)
+def view_test_sessions():
+    """Redirect to the frontend Sessions route."""
+    return RedirectResponse(url="/app#/sessions")
 
 @router.get("/test-sessions/react", summary="Test Sessions React view")
 def view_test_sessions_react(request: Request):

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -2,7 +2,7 @@ import { Typography } from '@mui/material'
 import PageLayout from '../components/PageLayout'
 
 export default function Home() {
-  return {
+  return (
     <PageLayout>
       <Typography variant="h4" component="h2">Home Page</Typography>
     </PageLayout>

--- a/frontend/src/pages/Sessions.jsx
+++ b/frontend/src/pages/Sessions.jsx
@@ -1,14 +1,15 @@
-import { Typography, CircularProgress, Alert } from '@mui/material'
+import {
+  Typography,
+  CircularProgress,
+  Alert,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+} from '@mui/material'
 import { useEffect, useState } from 'react'
 import PageLayout from '../components/PageLayout'
-import DataTable from '../components/DataTable'
-
-const columns = [
-  { field: 'id', headerName: 'ID' },
-  { field: 'candidate_name', headerName: 'Candidate' },
-  { field: 'score', headerName: 'Score' },
-  { field: 'status', headerName: 'Status' },
-]
 
 export default function Sessions() {
   const [sessions, setSessions] = useState([])
@@ -34,7 +35,28 @@ export default function Sessions() {
   } else if (error) {
     content = <Alert severity="error">{error}</Alert>
   } else {
-    content = <DataTable columns={columns} rows={sessions} />
+    content = (
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>ID</TableCell>
+            <TableCell>Candidate</TableCell>
+            <TableCell>Score</TableCell>
+            <TableCell>Status</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {sessions.map((s) => (
+            <TableRow key={s.id}>
+              <TableCell>{s.id}</TableCell>
+              <TableCell>{s.candidate_name}</TableCell>
+              <TableCell>{s.score}</TableCell>
+              <TableCell>{s.status}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    )
   }
 
   return (


### PR DESCRIPTION
## Summary
- update `/reports/test-sessions` endpoint to redirect to the SPA
- overhaul `Sessions.jsx` to use MUI `Table` directly and show loading/error states
- fix syntax in `Home.jsx`

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68574ba5b9788327aaeefd91a3cea0e2