### PR TITLE
Serve React at root

### DIFF
--- a/SurpassApp/reporting/routes.py
+++ b/SurpassApp/reporting/routes.py
@@ -5,8 +5,11 @@ from SurpassApp.reporting.client import fetch_test_sessions, check_surpass_conne
 from SurpassApp.reporting.models import TestSession
 import requests
 from fastapi.templating import Jinja2Templates
+from fastapi.responses import FileResponse
+from pathlib import Path
 
 templates = Jinja2Templates(directory="templates")
+FRONTEND_DIST = Path(__file__).resolve().parents[2] / "frontend" / "dist"
 
 router = APIRouter(prefix="/reports", tags=["Reporting"])
 
@@ -45,9 +48,6 @@ def view_test_sessions(request: Request):
     )
 
 @router.get("/test-sessions/react", summary="Test Sessions React view")
-def view_test_sessions_react(request: Request):
-    """Render a React-based page that fetches session data asynchronously."""
-    return templates.TemplateResponse(
-        "test_sessions_react.html",
-        {"request": request}
-    )
+def view_test_sessions_react():
+    """Serve the React application for sessions."""
+    return FileResponse(FRONTEND_DIST / "index.html")

--- a/main.py
+++ b/main.py
@@ -36,8 +36,13 @@ app.include_router(imports_router)
 app.include_router(users_router)
 
 @app.get("/")
-def home(request: Request):
-    """Render the application home screen with site overview."""
+def home():
+    """Serve the React single page application."""
+    return FileResponse(FRONTEND_DIST / "index.html")
+
+@app.get("/legacy")
+def legacy_home(request: Request):
+    """Legacy home page with Jinja templates."""
     return templates.TemplateResponse(
         "home.html", {"request": request, "title": "Home"}
     )


### PR DESCRIPTION
## Summary
- serve React build for the `/` route
- expose old Jinja home page at `/legacy`
- load React for `/reports/test-sessions/react`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68574ba7a7a08327b71f62c9c528d35f