### PR TITLE
Fix React home and menu

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,8 +1,7 @@
 #root {
   max-width: 1280px;
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  padding: 1rem;
 }
 
 .logo {

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,16 +1,57 @@
-import { AppBar, Toolbar, IconButton, Button } from '@mui/material'
+import {
+  AppBar,
+  Toolbar,
+  IconButton,
+  Button,
+  Menu,
+  MenuItem,
+  Typography,
+} from '@mui/material'
 import { Brightness4, Brightness7 } from '@mui/icons-material'
 import { Link as RouterLink } from 'react-router-dom'
+import { useState } from 'react'
 import PropTypes from 'prop-types'
 
 export default function Header({ mode, toggleTheme }) {
+  const [reportAnchor, setReportAnchor] = useState(null)
+  const [extraAnchor, setExtraAnchor] = useState(null)
+
+  const openReport = (e) => setReportAnchor(e.currentTarget)
+  const closeReport = () => setReportAnchor(null)
+  const openExtra = (e) => setExtraAnchor(e.currentTarget)
+  const closeExtra = () => setExtraAnchor(null)
+
   return (
     <AppBar position="static">
       <Toolbar>
-        <Button color="inherit" component={RouterLink} to="/">Home</Button>
-        <Button color="inherit" component={RouterLink} to="/sessions">Sessions</Button>
-        <Button color="inherit" component={RouterLink} to="/demo">Demo</Button>
-
+        <Typography variant="h6" sx={{ flexGrow: 1 }}>
+          Surpass Utilities
+        </Typography>
+        <Button color="inherit" component={RouterLink} to="/">
+          Home
+        </Button>
+        <Button color="inherit" onClick={openReport}>
+          Reports
+        </Button>
+        <Menu anchorEl={reportAnchor} open={Boolean(reportAnchor)} onClose={closeReport}>
+          <MenuItem component={RouterLink} to="/sessions" onClick={closeReport}>
+            Sessions
+          </MenuItem>
+          <MenuItem component="a" href="/reports/test-sessions" onClick={closeReport}>
+            Legacy Sessions
+          </MenuItem>
+        </Menu>
+        <Button color="inherit" onClick={openExtra}>
+          More
+        </Button>
+        <Menu anchorEl={extraAnchor} open={Boolean(extraAnchor)} onClose={closeExtra}>
+          <MenuItem component={RouterLink} to="/demo" onClick={closeExtra}>
+            Demo
+          </MenuItem>
+          <MenuItem component="a" href="/legacy" onClick={closeExtra}>
+            Legacy Home
+          </MenuItem>
+        </Menu>
         <IconButton color="inherit" onClick={toggleTheme} sx={{ marginLeft: 'auto' }}>
           {mode === 'light' ? <Brightness7 /> : <Brightness4 />}
         </IconButton>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -24,8 +24,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,16 +1,15 @@
 import { Typography, List, ListItem, Link } from '@mui/material'
-import PageLayout from '../components/PageLayout'
 
 export default function Home() {
   return (
-    <PageLayout>
-      <Typography variant="h4" component="h2" gutterBottom>
-        Welcome to Surpass Utilities
+    <>
+      <Typography variant="h3" component="h1" gutterBottom>
+        Surpass Utilities
       </Typography>
       <Typography paragraph>
-        This application offers a few tools that interface with the Surpass API.
+        A collection of small tools for working with the Surpass assessment platform.
       </Typography>
-
+      
       <Typography variant="h5" component="h3" gutterBottom>
         Site Map
       </Typography>
@@ -74,6 +73,6 @@ export default function Home() {
       <Typography paragraph>
         Use the navigation links above to explore the available utilities.
       </Typography>
-    </PageLayout>
+    </>
   )
 }

--- a/frontend/src/pages/Sessions.jsx
+++ b/frontend/src/pages/Sessions.jsx
@@ -9,7 +9,6 @@ import {
   TableCell,
 } from '@mui/material'
 import { useEffect, useState } from 'react'
-import PageLayout from '../components/PageLayout'
 
 export default function Sessions() {
   const [sessions, setSessions] = useState([])
@@ -60,11 +59,11 @@ export default function Sessions() {
   }
 
   return (
-    <PageLayout>
+    <>
       <Typography variant="h4" component="h2" gutterBottom>
         Sessions
       </Typography>
       {content}
-    </PageLayout>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- clean up default centering styles
- add dropdown menu with categories
- improve Home page copy and remove unused layout wrapper
- update Sessions page

## Testing
- `npm run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68574f2252708327bfcaf63a504ebb18