### PR TITLE
Remove unused legacy route

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -48,9 +48,6 @@ export default function Header({ mode, toggleTheme }) {
           <MenuItem component={RouterLink} to="/demo" onClick={closeExtra}>
             Demo
           </MenuItem>
-          <MenuItem component="a" href="/legacy" onClick={closeExtra}>
-            Legacy Home
-          </MenuItem>
         </Menu>
         <IconButton color="inherit" onClick={toggleTheme} sx={{ marginLeft: 'auto' }}>
           {mode === 'light' ? <Brightness7 /> : <Brightness4 />}

--- a/main.py
+++ b/main.py
@@ -41,12 +41,6 @@ def home():
     """Serve the React single page application."""
     return FileResponse(FRONTEND_DIST / "index.html")
 
-@app.get("/legacy")
-def legacy_home(request: Request):
-    """Legacy home page with Jinja templates."""
-    return templates.TemplateResponse(
-        "home.html", {"request": request, "title": "Home"}
-    )
 
 @app.get("/health")
 def health_check():


### PR DESCRIPTION
## Summary
- clean up server by dropping `/legacy` route
- update header menu links

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685754cd1e948327b3ca849cf69892c1