### PR TITLE
Create and link all placeholder pages, remove legacy

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,11 @@ import { lightTheme, darkTheme } from './theme'
 import Home from './pages/Home'
 import Sessions from './pages/Sessions'
 import Demo from './pages/Demo'
+import ReportsTestSessions from './pages/ReportsTestSessions'
+import ReportsTestSessionsReact from './pages/ReportsTestSessionsReact'
+import ReportsTestSessionsJson from './pages/ReportsTestSessionsJson'
+import ImportsPing from './pages/ImportsPing'
+import UsersPing from './pages/UsersPing'
 import { Header, Footer } from './components'
 
 export default function App() {
@@ -28,6 +33,11 @@ export default function App() {
             <Route path="/" element={<Home />} />
             <Route path="/sessions" element={<Sessions />} />
             <Route path="/demo" element={<Demo />} />
+            <Route path="/reports/test-sessions" element={<ReportsTestSessions />} />
+            <Route path="/reports/test-sessions/react" element={<ReportsTestSessionsReact />} />
+            <Route path="/reports/test-sessions/json" element={<ReportsTestSessionsJson />} />
+            <Route path="/imports/ping" element={<ImportsPing />} />
+            <Route path="/users/ping" element={<UsersPing />} />
             <Route path="*" element={<div style={{padding: 32}}><h2>404 - Page Not Found</h2></div>} />
           </Routes>
         </Container>

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -30,6 +30,9 @@ export default function Header({ mode, toggleTheme }) {
         <Button color="inherit" component={RouterLink} to="/">
           Home
         </Button>
+        <Button color="inherit" component={RouterLink} to="/reports/test-sessions">
+          Reports
+        </Button>
         <Button color="inherit" component={RouterLink} to="/sessions">
           Sessions
         </Button>
@@ -37,16 +40,25 @@ export default function Header({ mode, toggleTheme }) {
           Tools
         </Button>
         <Menu anchorEl={reportAnchor} open={Boolean(reportAnchor)} onClose={closeReport}>
-          <MenuItem component={RouterLink} to="/sessions" onClick={closeReport}>
-            Sessions
+          <MenuItem component={RouterLink} to="/reports/test-sessions" onClick={closeReport}>
+            Test Sessions (Legacy)
           </MenuItem>
-          <MenuItem component="a" href="/reports/test-sessions" onClick={closeReport}>
-            Legacy Sessions
+          <MenuItem component={RouterLink} to="/reports/test-sessions/react" onClick={closeReport}>
+            React View
+          </MenuItem>
+          <MenuItem component={RouterLink} to="/reports/test-sessions/json" onClick={closeReport}>
+            JSON Listing
           </MenuItem>
         </Menu>
         <Menu anchorEl={extraAnchor} open={Boolean(extraAnchor)} onClose={closeExtra}>
           <MenuItem component={RouterLink} to="/demo" onClick={closeExtra}>
             Demo
+          </MenuItem>
+          <MenuItem component={RouterLink} to="/imports/ping" onClick={closeExtra}>
+            Ping Imports
+          </MenuItem>
+          <MenuItem component={RouterLink} to="/users/ping" onClick={closeExtra}>
+            Ping Users
           </MenuItem>
         </Menu>
         <IconButton color="inherit" onClick={toggleTheme} sx={{ marginLeft: 'auto' }}>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -33,13 +33,13 @@ export default function Home() {
               </Typography>
               <ul style={{ paddingLeft: 20, margin: 0 }}>
                 <li>
-                  <Button component="a" href="/reports/test-sessions" size="small">Test Sessions (Legacy)</Button>
+                  <Button component={RouterLink} to="/reports/test-sessions" size="small">Test Sessions (Legacy)</Button>
                 </li>
                 <li>
-                  <Button component="a" href="/reports/test-sessions/react" size="small">React View</Button>
+                  <Button component={RouterLink} to="/reports/test-sessions/react" size="small">React View</Button>
                 </li>
                 <li>
-                  <Button component="a" href="/reports/test-sessions/json" size="small">JSON Listing</Button>
+                  <Button component={RouterLink} to="/reports/test-sessions/json" size="small">JSON Listing</Button>
                 </li>
                 <li>
                   <Button component={RouterLink} to="/sessions" size="small">Sessions (React Table)</Button>
@@ -59,7 +59,7 @@ export default function Home() {
               <Typography variant="body2" color="text.secondary" mb={2}>
                 Check the status of the imports module.
               </Typography>
-              <Button component="a" href="/imports/ping" size="small">Ping Imports</Button>
+              <Button component={RouterLink} to="/imports/ping" size="small">Ping Imports</Button>
             </CardContent>
           </Card>
         </Grid>
@@ -74,7 +74,7 @@ export default function Home() {
               <Typography variant="body2" color="text.secondary" mb={2}>
                 Check the status of the users module.
               </Typography>
-              <Button component="a" href="/users/ping" size="small">Ping Users</Button>
+              <Button component={RouterLink} to="/users/ping" size="small">Ping Users</Button>
             </CardContent>
           </Card>
         </Grid>

--- a/frontend/src/pages/ImportsPing.jsx
+++ b/frontend/src/pages/ImportsPing.jsx
@@ -1,0 +1,10 @@
+import { Typography, Box } from '@mui/material'
+
+export default function ImportsPing() {
+  return (
+    <Box p={4}>
+      <Typography variant="h4">Imports: Ping</Typography>
+      <Typography variant="body1" mt={2}>This is a placeholder for the imports ping page.</Typography>
+    </Box>
+  )
+}

--- a/frontend/src/pages/ReportsTestSessions.jsx
+++ b/frontend/src/pages/ReportsTestSessions.jsx
@@ -1,0 +1,10 @@
+import { Typography, Box } from '@mui/material'
+
+export default function ReportsTestSessions() {
+  return (
+    <Box p={4}>
+      <Typography variant="h4">Reports: Test Sessions (Legacy)</Typography>
+      <Typography variant="body1" mt={2}>This is a placeholder for the legacy test sessions report page.</Typography>
+    </Box>
+  )
+}

--- a/frontend/src/pages/ReportsTestSessionsJson.jsx
+++ b/frontend/src/pages/ReportsTestSessionsJson.jsx
@@ -1,0 +1,10 @@
+import { Typography, Box } from '@mui/material'
+
+export default function ReportsTestSessionsJson() {
+  return (
+    <Box p={4}>
+      <Typography variant="h4">Reports: Test Sessions (JSON Listing)</Typography>
+      <Typography variant="body1" mt={2}>This is a placeholder for the JSON listing of test sessions.</Typography>
+    </Box>
+  )
+}

--- a/frontend/src/pages/ReportsTestSessionsReact.jsx
+++ b/frontend/src/pages/ReportsTestSessionsReact.jsx
@@ -1,0 +1,10 @@
+import { Typography, Box } from '@mui/material'
+
+export default function ReportsTestSessionsReact() {
+  return (
+    <Box p={4}>
+      <Typography variant="h4">Reports: Test Sessions (React View)</Typography>
+      <Typography variant="body1" mt={2}>This is a placeholder for the React view of test sessions.</Typography>
+    </Box>
+  )
+}

--- a/frontend/src/pages/UsersPing.jsx
+++ b/frontend/src/pages/UsersPing.jsx
@@ -1,0 +1,10 @@
+import { Typography, Box } from '@mui/material'
+
+export default function UsersPing() {
+  return (
+    <Box p={4}>
+      <Typography variant="h4">Users: Ping</Typography>
+      <Typography variant="body1" mt={2}>This is a placeholder for the users ping page.</Typography>
+    </Box>
+  )
+}


### PR DESCRIPTION
Create placeholder pages and wire up all internal links to use React Router, ensuring full frontend navigation and removing legacy links.

---

[Open in Web](https://cursor.com/agents?id=bc-e3e6423f-37af-43e5-959f-c51deaf28216) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-e3e6423f-37af-43e5-959f-c51deaf28216)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)